### PR TITLE
wbremoveclaims functionality added

### DIFF
--- a/include/mw/StaticWikibaseSite.php
+++ b/include/mw/StaticWikibaseSite.php
@@ -84,6 +84,38 @@ class StaticWikibaseSite extends StaticSite {
 		], $data ) );
 	}
 
+		/**
+	 * Removes Wikibase claims using the wbremoveclaims API
+	 *
+	 * You do not need to send the CSRF 'token' and the 'action' parameters.
+	 *
+	 * @see https://www.wikidata.org/w/api.php?action=help&modules=wbremoveclaims
+	 *
+	 * @param $data array API data request
+	 * @param $claimGUID string containing claim's GUID to be retrieved
+	 *                   using getClaimsInProperty()->getID() 
+	 * @return mixed
+	 */
+	public function removeClaim( $data = [] ) {
+
+		// extends the API arguments adding a 'summary.pre' argument
+		if( isset( $data[ 'summary.pre' ] ) ) {
+			$data[ 'summary' ] = $data[ 'summary.pre' ] . $data[ 'summary' ];
+			unset( $data[ 'summary.pre' ] );
+		}
+
+		// extends the API arguments adding a 'summary.post' argument
+		if( isset( $data[ 'summary.post' ] ) ) {
+			$data[ 'summary' ] .= $data[ 'summary.post' ];
+			unset( $data[ 'summary.post' ] );
+		}
+
+		return $this->post( array_replace( [
+			'action' => 'wbremoveclaims',
+			'token'  => $this->getToken( \mw\Tokens::CSRF ),
+		], $data ) );
+	}
+
 	/**
 	 * Create an empty Wikibase data model related to this site
 	 *

--- a/include/wb/DataModel.php
+++ b/include/wb/DataModel.php
@@ -526,6 +526,39 @@ class DataModel {
 		return $this->getWikibaseSite()->editEntity( $data );
 	}
 
+		/**
+	 * Removes Wikibase claims using the wbremoveclaims API
+	 *
+	 * You do not need to send the CSRF 'token' and the 'action' parameters.
+	 *
+	 * @see https://www.wikidata.org/w/api.php?action=help&modules=wbremoveclaims
+	 *
+	 * @param $data array API data request
+	 * 	Allowed extensions:
+	 * 		summary.pre  Add something before the summary
+	 * 		summary.post Add something after  the summary
+	 * @return mixed
+	 */
+	public function removeClaim( $data = [] ) {
+
+		// can auto-generate a summary
+		if( !isset( $data['summary'] ) ) {
+			$data['summary'] = $this->getEditSummary();
+		}
+
+		// eventually prefill ID
+		if( !isset( $data['id'] ) ) {
+			$data['id'] = $this->hasEntityID() ? $this->getEntityID() : null;
+		}
+
+		// tell the wiki that a bot is performing the edit
+		if( !isset( $data['bot'] ) ) {
+			$data['bot'] = true;
+		}
+
+		return $this->getWikibaseSite()->removeClaim( $data );
+	}
+
 	/**
 	 * Static constructor from an associative array
 	 *


### PR DESCRIPTION
This is a suggestion to implement the [`wbremoveclaims`](https://www.wikidata.org/w/api.php?action=help&modules=wbremoveclaims) action from the Wikibase API.

After implemented, it should be used like the following example:
```php
<?php
require 'boz-mw/autoload-with-laser-cannon.php';

$wikidata = wiki( 'wikidatawiki' );

// query the Wikidata Sandbox
$data = $wikidata->fetchSingleEntity( 'Q4115189', [
	'props' => [
		'descriptions',
		'labels',
		'claims',
	],
] );

$newData = $datatrek->createDataModel();
$newData->removeClaim([
    'claim' => $data->getClaimsInProperty("P1")[0]->getID(),
    'summary' => "Remove existing P14 value (instance of)",
    'bot' => true,
]);
```